### PR TITLE
Fix typo and improve readability and documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It's totally experimental right now, and could easily crash your machine.
 
 Currently working:
 
-- FourZone keyboard colour control (`/sys/devices/platforms/hp-wmi/rgb-zones/zone0[0-3]`)
+- FourZone keyboard colour control (`/sys/devices/platform/hp-wmi/rgb-zones/zone0[0-3]`)
 - Omen hotkeys
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,36 +1,47 @@
 HP Omen special feature control for Linux
 -----------------------------------------
 
-This is a version of the hp-wmi kernel module that implements some of the features of HP Omen Command Centre.
+A version of the hp-wmi kernel module that implements some of the features of HP Omen Command Centre.
 
-It's totally experimental right now, and could easily crash your machine. 
+This is experimental software and could easily crash your machine.
 
 **USE AT YOUR OWN RISK**
 
 Currently working:
 
 - FourZone keyboard colour control (`/sys/devices/platform/hp-wmi/rgb-zones/zone0[0-3]`)
-- Omen hotkeys
+- Omen hotkeys (<kbd>F14</kbd>-<kbd>F17</kbd>)
 
 ## Installation
 
-1. Install dkms and kernel headers if needed (already present on Ubuntu)
+1. Install dkms and kernel headers
 
-1. Run `sudo make install`
+   Ubuntu: these packages are already installed
+   
+   Arch Linux: `sudo pacman -S dkms linux-headers`
 
-Module will be built and installed, and DKMS will manage rebuilding it on kernel updates.
+2. Run `sudo make install` inside this project's root directory
+
+   This will build and install the kernel module. DKMS will manage rebuilding it on kernel updates
 
 ## Usage
 
 The module creates four files in `/sys/devices/platform/hp-wmi/rgb_zones/` named `zone00 - zone03`.
 
-To change zone highlight color, just print hex colour value in RGB format to the respective file. e.g:
+To change a zone's highlight color, write a hex colour value in RGB format to the respective file. For example,
 
-`sudo bash -c 'echo 00FFFF > /sys/devices/platform/hp-wmi/rgb_zones/zone00'` to get sky-blue zone 0.
+`sudo bash -c 'echo 00FFFF > /sys/devices/platform/hp-wmi/rgb_zones/zone00'` will change the zone 0 backlight to sky blue.
 
-Omen and other hotkeys are bound to regular X11 keysyms, use your chosen desktop's hotkey manager to assign them to functions like any other key.
+Hotkeys are bound to regular X11 keysyms:
 
-## To do:
+ - Windows key lock: <kbd>F14</kbd>
+ - Omen: <kbd>F15</kbd>
+ - <kbd>Fn</kbd>+<kbd>Esc</kbd>: <kbd>F16</kbd>
+ - Disable touchpad: <kbd>F17</kbd>
+
+Use your desktop's hotkey manager to assign them to functions like any other key.
+
+## To do
 
 - [ ] FourZone brightness control
 - [ ] Fan control 


### PR DESCRIPTION
The first commit fixes a typo in the first path to the keyboard color control files.

The second commit makes various grammar/structural changes and adds more information about the Omen-specific hotkeys.